### PR TITLE
Minor change to package.json to use "scripts" instead of "script"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "devDependencies" : {
         "expresso" : ">=0.7.x"
     },
-    "script" : {
+    "scripts" : {
         "test" : "expresso"
     },
     "keywords" : [


### PR DESCRIPTION
This change reflects the docs from npm at
https://www.npmjs.org/doc/files/package.json.html and changes the "script"
keyword in package.json into "scripts" this removes the warnings that happen
when installing seq via `npm install`
